### PR TITLE
Add Dockerfile for 3.7-slim-buster-chrome using only Google Chrome, update CI build to build and deploy it

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         PYTHON: ['3.7']
         DISTRO: [slim-buster]
-        BROWSER: [all]
+        BROWSER: [all, chrome]
     env:
       DOCKER_TAG: ${{ matrix.PYTHON }}-${{ matrix.DISTRO }}-${{ matrix.BROWSER }}
       DOCKERFILE_PATH: "./${{ matrix.PYTHON }}/${{ matrix.DISTRO }}/\
@@ -44,7 +44,7 @@ jobs:
       matrix:
         PYTHON: ['3.7']
         DISTRO: [slim-buster]
-        BROWSER: [all]
+        BROWSER: [all, chrome]
     env:
       DOCKER_TAG: ${{ matrix.PYTHON }}-${{ matrix.DISTRO }}-${{ matrix.BROWSER }}
       DOCKERFILE_PATH: "./${{ matrix.PYTHON }}/${{ matrix.DISTRO }}/\
@@ -81,7 +81,7 @@ jobs:
       matrix:
         PYTHON: ['3.7']
         DISTRO: [slim-buster]
-        BROWSER: [all]
+        BROWSER: [all, chrome]
     env:
       DOCKER_TAG: ${{ matrix.PYTHON }}-${{ matrix.DISTRO }}-${{ matrix.BROWSER }}
     steps:
@@ -126,7 +126,7 @@ jobs:
       matrix:
         PYTHON: ['3.7']
         DISTRO: [slim-buster]
-        BROWSER: [all]
+        BROWSER: [all, chrome]
     env:
       DOCKER_TAG: ${{ matrix.PYTHON }}-${{ matrix.DISTRO }}-${{ matrix.BROWSER }}
     steps:

--- a/3.7/slim-buster/chrome/Dockerfile
+++ b/3.7/slim-buster/chrome/Dockerfile
@@ -10,25 +10,6 @@ LABEL org.opencontainers.image.description="Dockerised python with webdrivers fo
 # Ensure any piped commands exit on error
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install the latest versions of Mozilla Firefox and Geckodriver
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests --assume-yes \
-    curl \
-    bzip2 \
-    libgtk-3-0 \
-    libdbus-glib-1-2 \
-  && FIREFOX_DOWNLOAD_URL='https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64' \
-  && curl -sL "$FIREFOX_DOWNLOAD_URL" | tar -xj -C /opt \
-  && ln -s /opt/firefox/firefox /usr/local/bin/ \
-  && BASE_URL='https://github.com/mozilla/geckodriver/releases/download' \
-  && VERSION=$(curl -sL 'https://api.github.com/repos/mozilla/geckodriver/releases/latest' | grep tag_name | cut -d '"' -f 4) \
-  && curl -sL "${BASE_URL}/${VERSION}/geckodriver-${VERSION}-linux64.tar.gz" | tar -xz -C /usr/local/bin \
-  && apt-get purge -y \
-    curl \
-    bzip2 \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /tmp/* /usr/share/doc/* /var/cache/* /var/lib/apt/lists/* /var/tmp/*
-
 # Install the latest versions of Google Chrome and Chromedriver
 # Patches Chrome launch script to disable /dev/shm and sandbox for use in docker
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \


### PR DESCRIPTION
[Add Chrome only image](https://app.gitkraken.com/glo/board/5e83cce83188c3002aa2a88c/card/5e83cf422e6a760029847755)